### PR TITLE
Clean up Makefile and add support for running unit tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,31 +3,45 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-ifndef YAPPS
-	export YAPPS = third_party/yapps2/yapps2.py
-endif
+.PHONY: all
+.PHONY: build parser extensions
+.PHONY: tests unit_tests no_whitespace_tests whitespace_tests test_function_registry test_opt
+.PHONY: clean clean_build clean_tests
 
-ifndef PYTHON
-	PYTHON = $(which python)
-endif
+PYTHON ?= python
+PIP ?= pip
 
-CRUNNER = $(PYTHON) scripts/crunner.py
 COMPILER = $(PYTHON) scripts/spitfire-compile
+CRUNNER = $(PYTHON) scripts/crunner.py
+UNITTEST = $(PYTHON) -m unittest
+YAPPS = $(PYTHON) third_party/yapps2/yapps2.py
 
-spitfire/compiler/parser.py: spitfire/compiler/parser.g
-	$(YAPPS) spitfire/compiler/parser.g
+
+all: build
+
+
+build: parser extensions
 
 parser: spitfire/compiler/parser.py
 
-all: parser
+spitfire/compiler/parser.py: spitfire/compiler/parser.g third_party/yapps2/yapps2.py third_party/yapps2/yappsrt.py
+	$(YAPPS) spitfire/compiler/parser.g
 
-.PHONY : test_function_registry
-test_function_registry: parser
+extensions: spitfire/runtime/_baked.so spitfire/runtime/_template.so spitfire/runtime/_udn.so
+
+spitfire/runtime/_baked.so spitfire/runtime/_template.so spitfire/runtime/_udn.so: spitfire/runtime/_baked.c spitfire/runtime/_template.c spitfire/runtime/_udn.c
+	$(PIP) install --user --editable .
+
+
+tests: unit_tests no_whitespace_tests whitespace_tests test_function_registry test_opt
+
+unit_tests: build
+	$(UNITTEST) discover -s spitfire -p '*_test.py'
+
+test_function_registry: clean_tests build
 	$(CRUNNER) -O3 --compile --test-input tests/input/search_list_data.pye -qt tests/test-function-registry.txtx tests/i18n-7.txtx --function-registry-file tests/test-function-registry.cnf
 
-.PHONY : no_whitespace_tests
-no_whitespace_tests: parser
-	$(call _clean_tests)
+no_whitespace_tests: clean_tests build
 	$(COMPILER) tests/*.txt tests/*.tmpl
 	$(CRUNNER) --test-input tests/input/search_list_data.pye -qt tests/*.txt tests/*.tmpl
 	$(COMPILER) -O1 tests/*.txt tests/*.tmpl
@@ -37,9 +51,7 @@ no_whitespace_tests: parser
 	$(COMPILER) -O3 tests/*.txt tests/*.tmpl
 	$(CRUNNER) -O3 --test-input tests/input/search_list_data.pye -qt tests/*.txt tests/*.tmpl
 
-.PHONY : whitespace_tests
-whitespace_tests: parser
-	$(call _clean_tests)
+whitespace_tests: clean_tests build
 	$(COMPILER) --preserve-optional-whitespace tests/*.txt tests/*.tmpl
 	$(CRUNNER) --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl
 	$(COMPILER) -O1 --preserve-optional-whitespace tests/*.txt tests/*.tmpl
@@ -49,39 +61,33 @@ whitespace_tests: parser
 	$(COMPILER) -O3 --preserve-optional-whitespace tests/*.txt tests/*.tmpl
 	$(CRUNNER) -O3 --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl
 
-.PHONY : test_opt
-test_opt: parser
-	$(call _clean_tests)
+test_opt: clean_tests build
 	$(COMPILER) -O4 tests/*.txt tests/*.tmpl tests/*.o4txt
 	$(CRUNNER) -O4 --test-input tests/input/search_list_data.pye -qt tests/*.txt tests/*.tmpl tests/*.o4txt
 	$(COMPILER) -O4 --preserve-optional-whitespace tests/*.txt tests/*.tmpl tests/*.o4txt
 	$(CRUNNER) -O4 --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl tests/*.o4txt
 
-
-.PHONY : xhtml_tests
-xhtml_tests: clean_tests parser
+xhtml_tests: clean_tests build
 	$(COMPILER) --xspt-mode tests/*.xhtml
 	$(CRUNNER) --xspt-mode --test-input tests/input/search_list_data.pye --test-output output-xhtml -qt tests/*.xhtml
 
-.PHONY : tests
-tests: no_whitespace_tests whitespace_tests test_function_registry test_opt
 
-define _clean_tests
+clean: clean_build clean_tests
+
+clean_build:
+	@find spitfire -name '*.pyc' -exec rm {} \;
+	@find third_party -name '*.pyc' -exec rm {} \;
+	@find spitfire -name '*.so' -exec rm {} \;
+	@find third_party -name '*.so' -exec rm {} \;
+	@rm -f spitfire/compiler/parser.py
+	@rm -rf build
+	@if [[ $$($(PIP) show spitfire | fgrep Location: | awk '{print $$2}') == $(PWD) ]]; then \
+		$(PIP) uninstall --yes spitfire; \
+	 fi
+	@rm -rf spitfire.egg-info
+
+clean_tests:
 	@rm -f tests/*.py
 	@rm -f tests/*.pyc
 	@find tests -name '*.failed' -exec rm {} \;
 	@touch tests/__init__.py
-endef
-
-.PHONY : clean
-clean: clean_tests
-	@find . -name '*.pyc' -exec rm {} \;
-	@rm -f spitfire/compiler/parser.py
-	@rm -rf build
-
-.PHONY : clean_tests
-clean_tests:
-	$(call _clean_tests)
-
-.PHONE : clean_all
-clean_all : clean clean_tests


### PR DESCRIPTION
- Use pip to build and locally install for development so
  that extensions are compiled correctly.
- Always use yapps from third_party.
- Correctly express build dependencies.
- Add support for running unit tests with `python -m unittest discover`.
- Properly clean up built files and local pip installations.
- Streamline variable setting and phony target declarations.