### PR TITLE
Fix codegen for EchoNode to ensure it is marked as using buffer write.

### DIFF
--- a/spitfire/compiler/codegen.py
+++ b/spitfire/compiler/codegen.py
@@ -558,6 +558,7 @@ class CodeGenerator(object):
     return [code_node]
 
   def codegenASTEchoNode(self, node):
+    self.function_stack[-1].uses_buffer_write = True
     node_list = []
 
     true_expression = self.generate_python(


### PR DESCRIPTION
This change fixes the test suite, which is currently failing with
```
Traceback (most recent call last):
  File "scripts/crunner.py", line 142, in process_file
    current_output = template.main().encode('utf8')
NameError: global name '_buffer_write' is not defined
```

Progress on #26