### PR TITLE
Remove use of psyco and the associated "O4" optimization level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,6 @@ whitespace_tests: clean_tests build
 	$(COMPILER) -O3 --preserve-optional-whitespace tests/*.txt tests/*.tmpl
 	$(CRUNNER) -O3 --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl
 
-test_opt: clean_tests build
-	$(COMPILER) -O4 tests/*.txt tests/*.tmpl tests/*.o4txt
-	$(CRUNNER) -O4 --test-input tests/input/search_list_data.pye -qt tests/*.txt tests/*.tmpl tests/*.o4txt
-	$(COMPILER) -O4 --preserve-optional-whitespace tests/*.txt tests/*.tmpl tests/*.o4txt
-	$(CRUNNER) -O4 --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl tests/*.o4txt
-
 xhtml_tests: clean_tests build
 	$(COMPILER) --xspt-mode tests/*.xhtml
 	$(CRUNNER) --xspt-mode --test-input tests/input/search_list_data.pye --test-output output-xhtml -qt tests/*.xhtml

--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ I note most of the progress in the [change log](http://spitfire.googlecode.com/s
 
 Spitfire has a basic optimizer that can make certain operations much faster. I found a basic 10x1000 table generation benchmark written by the Genshi team. I modified it to add Cheetah (my baseline performance target) and Spitfire. This is by no means exhaustive proof that Spitfire is always fast, just that in a simple case of burning through a loop of generating text, it's not too shabby.
 
-PN: Note, to run the bigtable test, you'll need psyco http://psyco.sourceforge.net/
-
 ```
 hannosch:spitfire hannosch$ python tests/perf/bigtable.py
 Genshi tag builder                            671.49 ms
@@ -59,7 +57,6 @@ Spitfire template                              65.32 ms
 Spitfire template -O1                          40.19 ms
 Spitfire template -O2                          15.99 ms
 Spitfire template -O3                          16.02 ms
-Spitfire template -O4                          11.09 ms
 StringIO                                       80.85 ms
 cStringIO                                      16.52 ms
 list concat                                    12.93 ms

--- a/doc/SpitfireInstallationInstructions.md
+++ b/doc/SpitfireInstallationInstructions.md
@@ -1,5 +1,4 @@
 # Quick Installation Notes #
-You may need to install psyco. Run 'sudo apt-get install psyco' or the equivalent if needed.
 
 Copy this code into an file called example.spt:
 ```

--- a/scripts/spitfire-compile
+++ b/scripts/spitfire-compile
@@ -43,31 +43,6 @@ def process_file(compiler, filename, options):
       print >> sys.stderr, e
     sys.exit(1)
 
-# selectively enable psyco on import methods
-def init_psyco(options):
-  if options.x_psyco:
-    try:
-      import psyco
-    except ImportError:
-      print >> sys.stderr, 'WARNING: unable to import psyco'
-      return
-
-    import re
-    psyco.cannotcompile(re.compile)
-
-    if options.x_psyco_profile:
-      psyco.log()
-      psyco.profile()
-    else:
-      import spitfire.compiler.scanner
-      psyco.bind(spitfire.compiler.scanner.SpitfireScanner.scan)
-      import copy
-      psyco.bind(copy.deepcopy)
-      from third_party.yapps2 import yappsrt
-      psyco.bind(yappsrt.Scanner.token)
-      import spitfire.compiler.ast
-      psyco.bind(spitfire.compiler.ast.NodeList.__iter__)
-
 
 if __name__ == '__main__':
   reload(sys)
@@ -81,8 +56,6 @@ if __name__ == '__main__':
   if options.version:
     print >> sys.stderr, 'spitfire %s' % spitfire.__version__
     sys.exit(0)
-
-  init_psyco(options)
 
   compiler_args = sptcompiler.Compiler.args_from_optparse(options)
   compiler = sptcompiler.Compiler(**compiler_args)

--- a/spitfire/compiler/codegen.py
+++ b/spitfire/compiler/codegen.py
@@ -191,11 +191,6 @@ class CodeGenerator(object):
     #   logging.warning("throwing away defined main function because it is not a base class %s %s", self.ast_root.source_path)
     #   logging.warning("%s", flatten_tree(node.main_function))
 
-    # Don't enable psyco for libraries since there is no class. We might want
-    # to iterate over the library functions and enable it for them instead.
-    if not node.library and self.options and self.options.enable_psyco:
-      module_code.append_line('spitfire.runtime.template.enable_psyco(%(classname)s)' % vars())
-
     module_code.append_line(run_tmpl % vars(node))
 
     return [module_code]

--- a/spitfire/compiler/options.py
+++ b/spitfire/compiler/options.py
@@ -114,7 +114,6 @@ class AnalyzerOptions(object):
     # Disallow the use of raw in a template.
     self.no_raw = False
 
-    self.enable_psyco = False
     self.__dict__.update(kargs)
 
   def update(self, **kargs):
@@ -146,15 +145,11 @@ o3_options.cache_filtered_placeholders = True
 o3_options.omit_local_scope_search = True
 o3_options.batch_buffer_writes = True
 
-o4_options = copy.copy(o3_options)
-o4_options.enable_psyco = True
-
 optimizer_map = {
     0: default_options,
     1: o1_options,
     2: o2_options,
     3: o3_options,
-    4: o4_options,
 }
 
 
@@ -191,12 +186,6 @@ def add_common_options(op):
   op.add_option('-o', '--output-file', dest='output_file', default=None)
   op.add_option('--xspt-mode', action='store_true', default=False,
                 help='enable attribute language syntax')
-  op.add_option('--x-enable-psyco', dest='x_psyco', default=False,
-                action='store_true',
-                help='disable psyco')
-  op.add_option('--x-psyco-profile',
-                action='store_true',
-                help='enable psyco profiler logging')
 
   op.add_option('--disable-filters', dest='enable_filters',
                 action='store_false', default=True)

--- a/spitfire/runtime/template.py
+++ b/spitfire/runtime/template.py
@@ -79,11 +79,6 @@ class SpitfireTemplate(_template.BaseSpitfiretemplate):
     return BufferIO()
 
 
-def enable_psyco(template_class):
-  import psyco
-  psyco.bind(SpitfireTemplate)
-  psyco.bind(template_class)
-
 def template_method(function):
   function.template_method = True
   function.skip_filter = True

--- a/tests/perf/bigtable.py
+++ b/tests/perf/bigtable.py
@@ -152,12 +152,6 @@ if SpitfireTemplate:
         spitfire_src, 'spitfire_tmpl_o3', spitfire.compiler.analyzer.o3_options,
         {'enable_filters':enable_filters})
 
-    spitfire_tmpl_o4 = spitfire.compiler.util.load_template(
-        spitfire_src, 'spitfire_tmpl_o4', spitfire.compiler.analyzer.o4_options,
-        {'enable_filters':enable_filters})
-    # run once to get psyco warmed up
-    spitfire_tmpl_o4(search_list=[{'table':table}]).main()
-
 
     def test_spitfire():
         """Spitfire template"""
@@ -179,11 +173,6 @@ if SpitfireTemplate:
         data = spitfire_tmpl_o3(search_list=[{'table':table}]).main()
         #print "spitfire -O3", len(data)
 
-    def test_spitfire_o4():
-        """Spitfire template -O4"""
-        data = spitfire_tmpl_o4(search_list=[{'table':table}]).main()
-        #print "spitfire -O4", len(data)
-
 if CheetahTemplate:
     cheetah_src = """<table>
 #for $row in $table
@@ -199,7 +188,7 @@ if CheetahTemplate:
     # force compile
     post = set([k for k, v in sys.modules.iteritems() if v])
     #print post - pre
-    
+
     #print type(cheetah_template)
     cheetah_template.respond()
     cheetah_template = type(cheetah_template)
@@ -282,7 +271,7 @@ if et:
         et.tostring(_table)
 
 if cet:
-    def test_cet(): 
+    def test_cet():
         """cElementTree"""
         _table = cet.Element('table')
         for row in table:
@@ -328,7 +317,7 @@ def test_python_stringio():
     """StringIO"""
     buffer = StringIO.StringIO()
     write = buffer.write
-    
+
     write('<table>\n')
     for row in table:
         write('<tr>\n')
@@ -339,12 +328,12 @@ def test_python_stringio():
         write('</tr>\n')
     write('</table>')
     return buffer.getvalue()
-    
+
 def test_python_array():
     """list concat"""
     buffer = []
     write = buffer.append
-    
+
     write('<table>\n')
     for row in table:
         write('<tr>\n')
@@ -364,7 +353,7 @@ def run(which=None, number=10):
              'test_et', 'test_cet', 'test_clearsilver', 'test_django',
              'test_cheetah',
              'test_spitfire', 'test_spitfire_o1',
-             'test_spitfire_o2', 'test_spitfire_o3', 'test_spitfire_o4',
+             'test_spitfire_o2', 'test_spitfire_o3',
              'test_python_stringio', 'test_python_cstringio', 'test_python_array'
              ]
 


### PR DESCRIPTION
The psyco-enabled code has been off-by-default since 2010. The psyco project
is dead and unmaintained; its last release was in 2008.

Progress on #26