### PR TITLE
Fix import in i18n macro module

### DIFF
--- a/spitfire/compiler/macros/i18n.py
+++ b/spitfire/compiler/macros/i18n.py
@@ -11,6 +11,7 @@ from spitfire.compiler import analyzer
 from spitfire.compiler.ast import *
 from spitfire.compiler.visitor import print_tree
 from spitfire import text
+from spitfire.compiler import util
 
 
 # generate a reasonable substitute name from a raw placeholder node
@@ -53,7 +54,7 @@ def macro_i18n(macro_node, arg_map, compiler):
 
   # generate a fake translation for now to verify this is working
   # most apps will have to stub this part out somehow i think
-  macro_content_ast = spitfire.compiler.util.parse(macro_node.value,
+  macro_content_ast = util.parse(macro_node.value,
                                                    'i18n_goal')
   i18n_msg = make_i18n_message(macro_node.value, macro_content_ast)
   i18n_msg_utf8 = i18n_msg.encode(sys.getdefaultencoding())


### PR DESCRIPTION
This change fixes the test suite, which is currently failing with
```
Traceback (most recent call last):
  File "/Users/nicksay/dev/spitfire/spitfire/compiler/analyzer_test.py", line 557, in test_allow_raw_macro_no_error
    semantic_analyzer.get_ast()
  File "spitfire/test_util.py", line 119, in __call__
    result = self._func(*args, **kwargs)
  File "spitfire/compiler/analyzer.py", line 87, in get_ast
    ast_node_list = self.build_ast(self.parse_root)
  File "spitfire/compiler/analyzer.py", line 99, in build_ast
    ast_node_list = method(node)
  File "spitfire/compiler/analyzer.py", line 155, in analyzeTemplateNode
    built_nodes = self.build_ast(pn)
  File "spitfire/compiler/analyzer.py", line 99, in build_ast
    ast_node_list = method(node)
  File "spitfire/compiler/analyzer.py", line 402, in analyzeDefNode
    function.extend(self.build_ast(pn))
  File "spitfire/compiler/analyzer.py", line 99, in build_ast
    ast_node_list = method(node)
  File "spitfire/compiler/analyzer.py", line 467, in analyzeMacroNode
    return self.handleMacro(pnode, macro_function, macro_parse_rule)
  File "spitfire/compiler/analyzer.py", line 430, in handleMacro
    macro_output = macro_function(pnode, kargs_map, self.compiler)
  File "spitfire/compiler/macros/i18n.py", line 56, in macro_i18n
    macro_content_ast = spitfire.compiler.util.parse(macro_node.value,
NameError: global name 'spitfire' is not defined
```

Closes #26