### PR TITLE
Improve test suite runner to fail on errors and track test execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # Build
 .PHONY: build parser extensions
 # Test
-.PHONY: test tests unit_tests no_whitespace_tests whitespace_tests test_function_registry test_opt
+.PHONY: test tests unit_tests no_whitespace_tests whitespace_tests function_registry_tests optimizer_tests
 # Clean up
 .PHONY: clean clean_build clean_tests
 # Format code
@@ -59,41 +59,45 @@ lint:
 
 test: tests
 
-tests: unit_tests no_whitespace_tests whitespace_tests test_function_registry test_opt
+tests: unit_tests no_whitespace_tests whitespace_tests function_registry_tests optimizer_tests
 
 unit_tests: build
 	$(UNITTEST) discover -s spitfire -p '*_test.py'
 
 test_function_registry: build
 	$(call _clean_tests)
-	$(CRUNNER) -O3 --compile --test-input tests/input/search_list_data.pye -qt tests/test-function-registry.txtx tests/i18n-7.txtx --function-registry-file tests/test-function-registry.cnf
+	$(CRUNNER) -O3 --compile --function-registry-file tests/test-function-registry.cnf tests/*.txtx
 
 no_whitespace_tests: build
 	$(call _clean_tests)
 	$(COMPILER) tests/*.txt tests/*.tmpl
-	$(CRUNNER) --test-input tests/input/search_list_data.pye -qt tests/*.txt tests/*.tmpl
+	$(CRUNNER) tests/*.txt tests/*.tmpl
 	$(COMPILER) -O1 tests/*.txt tests/*.tmpl
-	$(CRUNNER) -O1 --test-input tests/input/search_list_data.pye -qt tests/*.txt tests/*.tmpl
+	$(CRUNNER) -O1 tests/*.txt tests/*.tmpl
 	$(COMPILER) -O2 tests/*.txt tests/*.tmpl
-	$(CRUNNER) -O2 --test-input tests/input/search_list_data.pye -qt tests/*.txt tests/*.tmpl
+	$(CRUNNER) -O2 tests/*.txt tests/*.tmpl
 	$(COMPILER) -O3 tests/*.txt tests/*.tmpl
-	$(CRUNNER) -O3 --test-input tests/input/search_list_data.pye -qt tests/*.txt tests/*.tmpl
+	$(CRUNNER) -O3 tests/*.txt tests/*.tmpl
 
 whitespace_tests: build
 	$(call _clean_tests)
 	$(COMPILER) --preserve-optional-whitespace tests/*.txt tests/*.tmpl
-	$(CRUNNER) --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl
+	$(CRUNNER) --preserve-optional-whitespace --test-output tests/output-preserve-whitespace tests/*.txt tests/*.tmpl
 	$(COMPILER) -O1 --preserve-optional-whitespace tests/*.txt tests/*.tmpl
-	$(CRUNNER) -O1 --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl
+	$(CRUNNER) -O1 --preserve-optional-whitespace --test-output tests/output-preserve-whitespace tests/*.txt tests/*.tmpl
 	$(COMPILER) -O2 --preserve-optional-whitespace tests/*.txt tests/*.tmpl
-	$(CRUNNER) -O2 --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl
+	$(CRUNNER) -O2 --preserve-optional-whitespace --test-output tests/output-preserve-whitespace tests/*.txt tests/*.tmpl
 	$(COMPILER) -O3 --preserve-optional-whitespace tests/*.txt tests/*.tmpl
-	$(CRUNNER) -O3 --preserve-optional-whitespace --test-input tests/input/search_list_data.pye --test-output output-preserve-whitespace -qt tests/*.txt tests/*.tmpl
+	$(CRUNNER) -O3 --preserve-optional-whitespace --test-output tests/output-preserve-whitespace tests/*.txt tests/*.tmpl
+
+optimizer_tests: clean_tests build
+	$(COMPILER) -O3 tests/*.o4txt
+	$(CRUNNER) -O3 tests/*.o4txt
 
 xhtml_tests: build
 	$(call _clean_tests)
 	$(COMPILER) --xspt-mode tests/*.xhtml
-	$(CRUNNER) --xspt-mode --test-input tests/input/search_list_data.pye --test-output output-xhtml -qt tests/*.xhtml
+	$(CRUNNER) --xspt-mode --test-output tests/output-xhtml tests/*.xhtml
 
 
 clean: clean_build clean_tests

--- a/scripts/crunner.py
+++ b/scripts/crunner.py
@@ -10,7 +10,10 @@ import copy
 import logging
 import os.path
 import sys
+import time
 import traceback
+
+import cStringIO as StringIO
 
 import spitfire.compiler.compiler
 import spitfire.compiler.options
@@ -63,123 +66,186 @@ def reset_sys_modules():
       del sys.modules[key]
 
 class TestRunner(object):
-  def __init__(self, compiler, options):
+  def __init__(self, compiler, options, files):
     self.compiler = compiler
     self.options = options
+    self.files = files
+    self._search_list = [
+      {'tier1': {'tier2': ResolveCounter()}},
+      {'nest': ResolveCounter()},
+      ResolveCounter(),
+    ]
     if options.test_input:
-      self._search_list = [
-        spitfire.runtime.runner.load_search_list(options.test_input),
-        {'tier1': {'tier2': ResolveCounter()}},
-        {'nest': ResolveCounter()},
-        ResolveCounter(),
-        ]
-    else:
-      self._search_list = []
+      self._search_list.append(
+          spitfire.runtime.runner.load_search_list(options.test_input))
+    self.buffer = StringIO.StringIO()
+    self.start_time = 0
+    self.finish_time = 0
+    self.num_tests_run = 0
+    self.num_tests_failed = 0
 
   # return a copy of the search_list for each set of tests
   @property
   def search_list(self):
     return copy.deepcopy(self._search_list)
 
-  def process_file(self, filename):
-    print_lines = []
-    def print_output(*args):
-      if options.quiet:
-        print_lines.append(args)
-      else:
-        print >> sys.stderr, ' '.join(args)
+  def run(self):
+    self.begin()
+    for filename in self.files:
+      self.process_file(filename)
+    self.end()
 
-    print_output("processing", filename)
+  def begin(self):
+    self.start_time = time.time()
+
+  def end(self):
+    self.finish_time = time.time()
+    print >> sys.stderr
+    if self.num_tests_failed > 0:
+      sys.stderr.write(self.buffer.getvalue())
+    print >> sys.stderr, '-' * 70
+    print >> sys.stderr, 'Ran %d tests in %0.3fs' % (
+            self.num_tests_run, self.finish_time - self.start_time)
+    print >> sys.stderr
+    if self.num_tests_failed > 0:
+      print >> sys.stderr, 'FAILED (failures=%d)' % self.num_tests_failed
+      sys.exit(1)
+    else:
+      print >> sys.stderr, 'OK'
+      sys.exit(0)
+
+  def process_file(self, filename):
+    buffer = StringIO.StringIO()
     reset_sys_modules()
+
     classname = spitfire.compiler.util.filename2classname(filename)
-    module_name = 'tests.%s' % classname
-    if not self.options.quiet or self.options.compile:
+    modulename = spitfire.compiler.util.filename2modulename(filename)
+    test_output_path = os.path.join(self.options.test_output,
+                                    classname + '.txt')
+
+    if self.options.verbose:
+      sys.stderr.write(modulename + ' ... ')
+
+    compile_failed = False
+    if self.options.debug or self.options.compile:
       try:
         self.compiler.compile_file(filename)
-      except Exception, e:
-        print >> sys.stderr, 'compile FAILED:', filename, e
-        raise
-    if not self.options.quiet:
-      if 'parse_tree' in self.options.debug_flags:
-        print "parse_tree:"
-        spitfire.compiler.visitor.print_tree(self.compiler._parse_tree)
-      if 'analyzed_tree' in self.options.debug_flags:
-        print "analyzed_tree:"
-        spitfire.compiler.visitor.print_tree(self.compiler._analyzed_tree)
-      if 'optimized_tree' in self.options.debug_flags:
-        print "optimized_tree:"
-        spitfire.compiler.visitor.print_tree(self.compiler._optimized_tree)
-      if 'hoisted_tree' in self.options.debug_flags:
-        print "hoisted_tree:"
-        spitfire.compiler.visitor.print_tree(self.compiler._hoisted_tree)
-      if 'source_code' in self.options.debug_flags:
-        print "source_code:"
-        for i, line in enumerate(self.compiler._source_code.split('\n')):
-          print '% 3s' % (i + 1), line
+      except Exception as e:
+        compile_failed = True
+        print >> buffer, '=' * 70
+        print >> buffer, 'FAIL:', modulename, '(' + filename + ')'
+        print >> buffer, '-' * 70
+        traceback.print_exc(None, buffer)
+      if self.options.debug:
+        if 'parse_tree' in self.options.debug_flags:
+          print >> buffer, "parse_tree:"
+          spitfire.compiler.visitor.print_tree(self.compiler._parse_tree, output=buffer)
+        if 'analyzed_tree' in self.options.debug_flags:
+          print >> buffer, "analyzed_tree:"
+          spitfire.compiler.visitor.print_tree(self.compiler._analyzed_tree, output=buffer)
+        if 'optimized_tree' in self.options.debug_flags:
+          print >> buffer, "optimized_tree:"
+          spitfire.compiler.visitor.print_tree(self.compiler._optimized_tree, output=buffer)
+        if 'hoisted_tree' in self.options.debug_flags:
+          print >> buffer, "hoisted_tree:"
+          spitfire.compiler.visitor.print_tree(self.compiler._hoisted_tree, output=buffer)
+        if 'source_code' in self.options.debug_flags:
+          print >> buffer, "source_code:"
+          for i, line in enumerate(self.compiler._source_code.split('\n')):
+            print >> buffer, '% 3s' % (i + 1), line
 
 
-    if self.options.test:
-      print_output("test", classname, '...')
+    test_failed = False
+    if not self.options.skip_test:
       import tests
 
+      current_output = None
       raised_exception = False
-
       try:
-        if not self.options.quiet or self.options.compile:
+        if self.options.debug or self.options.compile:
           template_module = spitfire.compiler.util.load_module_from_src(
-            self.compiler._source_code, filename, module_name)
+            self.compiler._source_code, filename, modulename)
         else:
-          template_module = spitfire.runtime.import_module_symbol(module_name)
-      except Exception, e:
-        print "dynamic import error"
-        print filename, module_name
-        raise
-
-      try:
-        template_class = getattr(template_module, classname)
-        template = template_class(search_list=self.search_list)
-        current_output = template.main().encode('utf8')
-      except Exception, e:
-        if not self.options.quiet:
-          logging.exception("test error:")
-        current_output = str(e)
+          template_module = spitfire.runtime.import_module_symbol(modulename)
+      except Exception as e:
+        # An exception here means the template is unavailble; the test fails.
+        test_failed = True
         raised_exception = True
+        current_output = str(e)
 
-      test_output_path = os.path.join(os.path.dirname(filename),
-                      self.options.test_output,
-                      classname + '.txt')
+      if not test_failed:
+        try:
+          template_class = getattr(template_module, classname)
+          template = template_class(search_list=self.search_list)
+          current_output = template.main().encode('utf8')
+        except Exception as e:
+          # An exception here doesn't meant that the test fails necessarily
+          # since libraries don't have a class; as long as the expected output
+          # matches the exception, the test passes.
+          raised_exception = True
+          current_output = str(e)
 
-      if self.options.accept_test_result:
-        test_file = open(test_output_path, 'w')
-        test_file.write(current_output)
-        test_file.close()
+      if not test_failed:
+        if self.options.test_accept_result:
+          test_file = open(test_output_path, 'w')
+          test_file.write(current_output)
+          test_file.close()
+        try:
+          test_file = open(test_output_path)
+        except IOError as e:
+          # An excpetion here means that the expected output is unavailbe;
+          # the test fails.
+          test_failed = True
+          raised_exception = True
+          current_output = str(e)
 
-      try:
-        test_file = open(test_output_path)
-      except IOError, e:
-        print "current output:"
-        print current_output
-        raise
+      if test_failed:
+        test_output = None
+      else:
+        test_output = test_file.read()
+        if current_output != test_output:
+          test_failed = True
+          if self.options.debug:
+            print >> buffer, "expected output:"
+            print >> buffer, test_output
+            print >> buffer, "actual output:"
+            print >> buffer, current_output
 
-      test_output = test_file.read()
-      if current_output != test_output:
-        current_output_path = os.path.join(
-          os.path.dirname(filename),
-          self.options.test_output,
-          classname + '.failed')
+      if compile_failed or test_failed:
+        self.num_tests_failed += 1
+        if self.options.verbose:
+          sys.stderr.write('FAIL\n')
+        else:
+          sys.stderr.write('F')
+        current_output_path = os.path.join(self.options.test_output,
+                                           classname + '.failed')
         f = open(current_output_path, 'w')
         f.write(current_output)
         f.close()
-        for line in print_lines:
-          print >> sys.stderr, ' '.join(line)
-        print >> sys.stderr, "FAILED:", classname
-        print >> sys.stderr, '  diff -u', test_output_path, current_output_path
-        print >> sys.stderr, '  %s -t' % sys.argv[0], filename
+        print >> buffer, '=' * 70
+        print >> buffer, 'FAIL:', modulename, '(' + filename + ')'
+        print >> buffer, '-' * 70
+        print >> buffer, 'Compare expected and actual output with:'
+        print >> buffer, '    diff -u', test_output_path, current_output_path
+        print >> buffer, 'Show debug information for the test with:'
+        test_cmd = [arg for arg in sys.argv if arg not in self.files]
+        if '--debug' not in test_cmd:
+          test_cmd.append('--debug')
+        test_cmd = ' '.join(test_cmd)
+        print >> buffer, '   ', test_cmd, filename
         if raised_exception:
-          print >> sys.stderr, current_output
-          traceback.print_exc(raised_exception)
+          print >> buffer, '-' * 70
+          print >> buffer, current_output
+          traceback.print_exc(None, buffer)
+        print >> buffer
+        self.buffer.write(buffer.getvalue())
       else:
-        print_output('OK')
+        if self.options.verbose:
+          sys.stderr.write('ok\n')
+        else:
+          sys.stderr.write('.')
+      self.num_tests_run += 1
+
 
 
 if __name__ == '__main__':
@@ -190,20 +256,25 @@ if __name__ == '__main__':
   op = OptionParser()
   spitfire.compiler.options.add_common_options(op)
   op.add_option('-c', '--compile', action='store_true', default=False)
-  op.add_option('-t', '--test', action='store_true', default=False)
-  op.add_option('--test-input')
-  op.add_option('--test-output', default='output',
+  op.add_option('--skip-test', action='store_true', default=False)
+  op.add_option('--test-input', default='tests/input/search_list_data.pye',
+                help='input data file for templates (.pkl or eval-able file)')
+  op.add_option('--test-output', default='tests/output',
           help="directory for output")
-  op.add_option('--accept-test-result', action='store_true', default=False,
+  op.add_option('--test-accept-result', action='store_true', default=False,
           help='accept current code output as correct for future tests')
-  op.add_option('-q', '--quiet', action='store_true', default=False)
-  op.add_option('-D', dest='debug_flags', action='store',
+  op.add_option('--debug', action='store_true', default=False)
+  op.add_option('--debug-flags', action='store',
                 default='hoisted_tree,source_code',
                 help='parse_tree, analyzed_tree, optimized_tree, hoisted_tree, source_code'
                 )
   op.add_option('--enable-c-accelerator', action='store_true', default=False)
   (options, args) = op.parse_args()
-  setattr(options, 'debug_flags', getattr(options, 'debug_flags').split(','))
+  if options.debug:
+    options.verbose = True
+    options.debug_flags = getattr(options, 'debug_flags').split(',')
+  else:
+    options.debug_flags = []
 
   spitfire.runtime.udn.set_accelerator(
     options.enable_c_accelerator, enable_test_mode=True)
@@ -212,6 +283,5 @@ if __name__ == '__main__':
         spitfire.compiler.compiler.Compiler.args_from_optparse(options))
   compiler = spitfire.compiler.compiler.Compiler(**compiler_args)
 
-  test_runner = TestRunner(compiler, options)
-  for filename in args:
-    test_runner.process_file(filename)
+  test_runner = TestRunner(compiler, options, args)
+  test_runner.run()

--- a/spitfire/compiler/util.py
+++ b/spitfire/compiler/util.py
@@ -20,13 +20,17 @@ valid_identfier = re.compile('[_a-z]\w*', re.IGNORECASE)
 
 
 def filename2classname(filename):
-  classname = os.path.splitext(
-      os.path.basename(filename))[0].replace('-', '_')
+  classname = os.path.splitext(os.path.basename(filename))[0].replace('-', '_')
   if not valid_identfier.match(classname):
     raise SyntaxError(
         'filename "%s" must yield valid python identifier: %s' % (filename,
                                                                   classname))
   return classname
+
+
+def filename2modulename(filename):
+  names = [filename2classname(p) for p in filename.split(os.path.sep)]
+  return '.'.join(names)
 
 
 # @return abstract syntax tree rooted on a TemplateNode

--- a/spitfire/compiler/visitor.py
+++ b/spitfire/compiler/visitor.py
@@ -35,8 +35,11 @@ class VisitNode(object):
 def flatten_tree(root):
   return TreeVisitor(root).get_text()
 
-def print_tree(root):
-  print flatten_tree(root)
+def print_tree(root, output=None):
+  if output:
+    print >> output, flatten_tree(root)
+  else:
+    print flatten_tree(root)
 
 # perform an in-order traversal of the AST and call the generate methods
 # in this case, we are generating python source code that should be somewhat


### PR DESCRIPTION
This change updates the test suite runner (`scripts/crunner.py`):
- Output test results similarly to `python -m unittest discover`, tracking
  the number of tests executed and their time
- Buffers test failures during execution and outputs traceback information
  for each at the end to make finding errors faster
- Replaces the `-t` option with `--skip-test`, making running the test the
  default behavior
- Replaces the `-q` option with `--verbose` and `--debug` for increasing levels
  of information, making the flags consistent with the compiler options
- Improves the `--debug` option to also show template output in addition to
  source tree information
- Provides defaults for `--test-input` and `--test-output` and makes the
  values relative the to the working directory to allow running tests in
  other locations in the future

Closes #37